### PR TITLE
Change mentions of Gitter to Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ read it carefully.
 ## How Can I Talk to You?
 
 Discussion often happens in the issues and pull requests.
-In addition, there is a [Gitter chat room](https://gitter.im/fatiando/fatiando) for the
+In addition, there is a [Slack chat room](http://contact.fatiando.org) for the
 Fatiando a Terra project where you can ask questions.
 
 

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@
 
 If you want to get involved with any of our projects, please see the
 `CONTRIBUTING.md` file inside any of them for instructions.
-We also have a Gitter chat room for all of Fatiando at https://gitter.im/fatiando/fatiando
+We also have an open Slack chat room for all of Fatiando at
+[contact.fatiando.org](http://contact.fatiando.org).
 
 This repository contains our standard [Contributing Guide](CONTRIBUTING.md),
 [Maintainers Guide](MAINTENANCE.md), and [Code of Conduct](CODE_OF_CONDUCT.md) that get
 copied to all Fatiando a Terra repositories.
 
-Please feel free to use these files for your own projects. 
-**If you make any changes that aren't specific to your project, 
+Please feel free to use these files for your own projects.
+**If you make any changes that aren't specific to your project,
 please contribute them back to this repository.**
 
 Pull requests (PRs) to all of our projects will be automatically opened once a PR is merged


### PR DESCRIPTION
We're prioritizing our Slack chatroom instead of Gitter and using a
domain forward in case we want to change from Slack to something else.