### PR TITLE
Comment about keeping docstrings to 79 characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,18 @@ make check   # Runs flake8 and black (in check mode)
 make lint    # Runs pylint, which is a bit slower
 ```
 
+#### Docstrings
+
+**All docstrings** should follow the
+[numpy style guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).
+All functions/classes/methods should have docstrings with a full description of all
+arguments and return values.
+
+While the maximum line length for code is automatically set by *Black*, docstrings
+must be formatted manually. To play nicely with Jupyter and IPython, **keep docstrings
+limited to 79 characters** per line. We don't have a good way of enforcing this
+automatically yet, so please do your best.
+
 ### Testing your code
 
 Automated testing helps ensure that our code is as free of bugs as it can be.
@@ -264,11 +276,6 @@ using <code>:func:\`package.module.function\`</code>,
 <code>:mod:\`package.module\`</code>.
 Sphinx will create a link to the automatically generated page for that
 function/class/module.
-
-**All docstrings** should follow the
-[numpy style guide](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt).
-All functions/classes/methods should have docstrings with a full description of all
-arguments and return values.
 
 ### Code Review
 


### PR DESCRIPTION
Otherwise Jupyter/IPython won't render the docstrings nicely in tab completion.

Fixes #9 and fatiando/verde#177