### PR TITLE
Replace versioneer for setuptools-scm

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -118,7 +118,7 @@ Mendeley, etc).
 
 We try to automate the release process as much as possible.
 Travis handles publishing new releases to PyPI and updating the documentation.
-The version number is set automatically using setuptools-scm based information it gets
+The version number is set automatically using setuptools-scm based on information it gets
 from git.
 There are a few steps that still must be done manually, though.
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -118,8 +118,8 @@ Mendeley, etc).
 
 We try to automate the release process as much as possible.
 Travis handles publishing new releases to PyPI and updating the documentation.
-The version number is set automatically using versioneer based information it gets from
-git.
+The version number is set automatically using setuptools-scm based information it gets
+from git.
 There are a few steps that still must be done manually, though.
 
 ### Draft a new Zenodo release


### PR DESCRIPTION
Related to fatiando/maintenance#4





**Reminders**:

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst` and the base `__init__.py` file for the package.
- [ ] Write detailed docstrings for all functions/classes/methods. It often helps to design better code if you write the docstrings first.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
- [ ] Add your full name, affiliation, and [ORCID](https://orcid.org) (optional) to the `AUTHORS.md` file (if you haven't already) in case you'd like to be listed as an author on the [Zenodo](https://zenodo.org/communities/fatiando) archive of the next release.
